### PR TITLE
Fixed python interpreter path

### DIFF
--- a/blockcheck.py
+++ b/blockcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # coding: utf-8
 import urllib.request
 import dns.resolver


### PR DESCRIPTION
Calling python3 via `/usr/bin/env python3` instead of `/usr/bin/python3`. It will fix system with non-standard python3 binary path (OSX with python3 from `brew`)
