### PR TITLE
* urlopen() arguments

### DIFF
--- a/blockcheck.py
+++ b/blockcheck.py
@@ -125,11 +125,11 @@ def _get_url(url, proxy=None, ip=None):
 
     if proxy:
         req.set_proxy(proxy, 'http')
-    
+
     req.add_header('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0')
 
     try:
-        opened = urllib.request.urlopen(req, timeout=15, cadefault=True)
+        opened = urllib.request.urlopen(req, timeout=15)
     except (urllib.error.URLError, socket.error): # we do not expect ssl.CertificateError here
         return (0, '')
     return (opened.status, str(opened.readall()))
@@ -137,7 +137,7 @@ def _get_url(url, proxy=None, ip=None):
 def test_dns():
     sites = dns_records_list
     sites_list = list(sites.keys())
-    
+
     print("[O] Тестируем DNS")
     print("[O] Получаем эталонные DNS с сервера")
     try:
@@ -201,7 +201,7 @@ def test_dns():
 def test_http_access(by_ip=False):
     sites = http_list
     proxy = proxy_addr
-    
+
     print("[O] Тестируем HTTP")
 
     siteresults = []


### PR DESCRIPTION
Выпадал на этом шаге, debian:

      [O] Тестируем HTTP
              Открываем  http://sukebei.nyaa.se/
      Traceback (most recent call last):
        File "./blockcheck.py", line 332, in <module>
          main()
        File "./blockcheck.py", line 277, in main
          http = test_http_access(True)
        File "./blockcheck.py", line 210, in test_http_access
          result = _get_url(site, ip=sites[site].get('ip') if by_ip else None)
        File "./blockcheck.py", line 132, in _get_url
          opened = urllib.request.urlopen(req, timeout=15, cadefault=True)
      TypeError: urlopen() got an unexpected keyword argument 'cadefault'
 