### PR TITLE
Починил _get_a_records

### DIFF
--- a/blockcheck.py
+++ b/blockcheck.py
@@ -108,7 +108,7 @@ def _get_a_records(sitelist, dnsserver=None):
             for item in _get_a_record(site, dnsserver):
                 result.append(item)
         except dns.exception.DNSException:
-            return ""
+            continue
 
     return sorted(result)
 


### PR DESCRIPTION
Не прерывать обработку списка сайтов при ошибке, просто переходить к следующему

Без этого, у меня все получения адресов не работали:
```
$ ./blockcheck.py 
[O] Тестируем DNS
[O] Получаем эталонные DNS с сервера
        Эталонные адреса:                ['5.178.68.100', '69.165.95.242', '78.110.160.185']
        Адреса через системный DNS:      
        Не удалось подключиться к Google DNS
        Не удалось подключиться к DNS AntiZapret

[O] Тестируем HTTP
        Открываем  http://sukebei.nyaa.se/
[✓] Сайт открывается
        Открываем  http://gelbooru.com/index.php?page=post&s=view&id=1989610
[☠] Сайт не открывается
        Открываем  http://skidows.ru/20648-nastoyaschiy-detektiv-true-detective-2-sezon-1-2-serii-iz-8-2015-hdtvrip-amedia.html
[☠] Сайт не открывается
        Открываем  http://gelbooru.com/
[✓] Сайт открывается
        Открываем  http://skidows.ru/
[☠] Сайт не открывается
        Открываем  http://sukebei.nyaa.se/?page=view&tid=395631
[☠] Сайт не открывается
        Открываем через прокси  http://sukebei.nyaa.se/
[✓] Сайт открывается
        Открываем через прокси  http://gelbooru.com/index.php?page=post&s=view&id=1989610
[✓] Сайт открывается
        Открываем через прокси  http://skidows.ru/20648-nastoyaschiy-detektiv-true-detective-2-sezon-1-2-serii-iz-8-2015-hdtvrip-amedia.html
[☠] Сайт не открывается
        Открываем через прокси  http://gelbooru.com/
[✓] Сайт открывается
        Открываем через прокси  http://skidows.ru/
[☠] Сайт не открывается
        Открываем через прокси  http://sukebei.nyaa.se/?page=view&tid=395631
[✓] Сайт открывается

[O] Тестируем HTTPS
        Открываем  https://2chru.net/
[☠] Сайт не открывается

[!] Результат:
[⚠] Ваш провайдер блокирует чужие DNS-серверы.
 Вам следует использовать шифрованный канал до DNS-серверов, например, через VPN, Tor или HTTPS/Socks прокси.
[⚠] У вашего провайдера "полный" DPI. Он отслеживает ссылки даже внутри прокси, поэтому вам следует использовать любое шифрованное соединение, например, VPN или Tor.
```

хотя вручную через dig(1) все было нормально:
```
 dig sukebei.nyaa.se gelbooru.com skidows.ru

; <<>> DiG 9.9.5-11-Debian <<>> sukebei.nyaa.se gelbooru.com skidows.ru
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 10797
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;sukebei.nyaa.se.               IN      A

;; ANSWER SECTION:
sukebei.nyaa.se.        232     IN      A       69.165.95.242

;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Thu Aug 13 12:44:08 MSK 2015
;; MSG SIZE  rcvd: 60

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9915
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;gelbooru.com.                  IN      A

;; ANSWER SECTION:
gelbooru.com.           232     IN      A       5.178.68.100

;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Thu Aug 13 12:44:08 MSK 2015
;; MSG SIZE  rcvd: 57

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 46885
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;skidows.ru.                    IN      A

;; AUTHORITY SECTION:
ru.                     1015    IN      SOA     a.dns.ripn.net. hostmaster.ripn.net. 4023951 86400 14400 2592000 3600

;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Thu Aug 13 12:44:08 MSK 2015
;; MSG SIZE  rcvd: 100
```
```
dig @8.8.4.4 sukebei.nyaa.se gelbooru.com skidows.ru

; <<>> DiG 9.9.5-11-Debian <<>> @8.8.4.4 sukebei.nyaa.se gelbooru.com skidows.ru
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24597
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;sukebei.nyaa.se.               IN      A

;; ANSWER SECTION:
sukebei.nyaa.se.        299     IN      A       69.165.95.242

;; Query time: 57 msec
;; SERVER: 8.8.4.4#53(8.8.4.4)
;; WHEN: Thu Aug 13 12:44:40 MSK 2015
;; MSG SIZE  rcvd: 60

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 21869
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;gelbooru.com.                  IN      A

;; ANSWER SECTION:
gelbooru.com.           299     IN      A       5.178.68.100

;; Query time: 58 msec
;; SERVER: 8.8.4.4#53(8.8.4.4)
;; WHEN: Thu Aug 13 12:44:40 MSK 2015
;; MSG SIZE  rcvd: 57

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 63418
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;skidows.ru.                    IN      A

;; AUTHORITY SECTION:
ru.                     1023    IN      SOA     a.dns.ripn.net. hostmaster.ripn.net. 4023951 86400 14400 2592000 3600

;; Query time: 1 msec
;; SERVER: 8.8.4.4#53(8.8.4.4)
;; WHEN: Thu Aug 13 12:44:40 MSK 2015
;; MSG SIZE  rcvd: 100
```
```
dig @107.150.11.192 sukebei.nyaa.se gelbooru.com skidows.ru 

; <<>> DiG 9.9.5-11-Debian <<>> @107.150.11.192 sukebei.nyaa.se gelbooru.com skidows.ru
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1209
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;sukebei.nyaa.se.               IN      A

;; ANSWER SECTION:
sukebei.nyaa.se.        165     IN      A       107.150.11.192

;; Query time: 150 msec
;; SERVER: 107.150.11.192#53(107.150.11.192)
;; WHEN: Thu Aug 13 12:45:15 MSK 2015
;; MSG SIZE  rcvd: 60

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 13801
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;gelbooru.com.                  IN      A

;; ANSWER SECTION:
gelbooru.com.           165     IN      A       107.150.11.192

;; Query time: 145 msec
;; SERVER: 107.150.11.192#53(107.150.11.192)
;; WHEN: Thu Aug 13 12:45:15 MSK 2015
;; MSG SIZE  rcvd: 57

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 23418
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;skidows.ru.                    IN      A

;; Query time: 149 msec
;; SERVER: 107.150.11.192#53(107.150.11.192)
;; WHEN: Thu Aug 13 12:45:15 MSK 2015
;; MSG SIZE  rcvd: 39
```

И с моими изменениями:
```
$ ./blockcheck.py 
[O] Тестируем DNS
[O] Получаем эталонные DNS с сервера
        Эталонные адреса:                ['5.178.68.100', '69.165.95.242', '78.110.160.185']
        Адреса через системный DNS:      ['5.178.68.100', '69.165.95.242', '78.110.160.185']
        Адреса через Google DNS:         ['5.178.68.100', '69.165.95.242', '78.110.160.185']
        Адреса через DNS AntiZapret:     ['107.150.11.192', '107.150.11.192', '107.150.11.192']
[✓] DNS записи не подменяются
[✓] DNS не перенаправляется

[O] Тестируем HTTP
        Открываем  http://gelbooru.com/index.php?page=post&s=view&id=1989610
[☠] Сайт не открывается
        Открываем  http://skidows.ru/
[☠] Сайт не открывается
        Открываем  http://skidows.ru/20648-nastoyaschiy-detektiv-true-detective-2-sezon-1-2-serii-iz-8-2015-hdtvrip-amedia.html
[☠] Сайт не открывается
        Открываем  http://sukebei.nyaa.se/?page=view&tid=395631
[☠] Сайт не открывается
        Открываем  http://gelbooru.com/
[✓] Сайт открывается
        Открываем  http://sukebei.nyaa.se/
[✓] Сайт открывается
        Открываем через прокси  http://gelbooru.com/index.php?page=post&s=view&id=1989610
[✓] Сайт открывается
        Открываем через прокси  http://skidows.ru/
[☠] Сайт не открывается
        Открываем через прокси  http://skidows.ru/20648-nastoyaschiy-detektiv-true-detective-2-sezon-1-2-serii-iz-8-2015-hdtvrip-amedia.html
[☠] Сайт не открывается
        Открываем через прокси  http://sukebei.nyaa.se/?page=view&tid=395631
[✓] Сайт открывается
        Открываем через прокси  http://gelbooru.com/
[✓] Сайт открывается
        Открываем через прокси  http://sukebei.nyaa.se/
[✓] Сайт открывается

[O] Тестируем HTTPS
        Открываем  https://2chru.net/
[☠] Сайт не открывается

[!] Результат:
[⚠] У вашего провайдера "полный" DPI. Он отслеживает ссылки даже внутри прокси, поэтому вам следует использовать любое шифрованное соединение, например, VPN или Tor.
```
Видимо, было сломлено в fb533703e529203021ad7579fbf71dd5783297c2

@sockeye44 у меня нету опыта с Python, так что я не знаю насколько мои изменения правильные и как они себя поведут в той ситуации, для которой тот коммит был предназначен.
Так что было-бы неплохо, если-бы Вы проверили что мое изменение не ломает тот функционал.