### PR TITLE
isup.me: fix isup.me HTTPS problem and unexpected page problems

### DIFF
--- a/blockcheck.py
+++ b/blockcheck.py
@@ -393,13 +393,21 @@ def test_http_access(by_ip=False):
             print("[✓] Сайт открывается")
             successes += 1
         else:
-            print("[☠] Сайт не открывается, пробуем через прокси")
+            if result[0]  == sites[site]['status']:
+                print("[☠] Получен неожиданный ответ, скорее всего, "
+                      "страница-заглушка провайдера. Пробуем через прокси.")
+            else:
+                print("[☠] Сайт не открывается, пробуем через прокси")
             result_proxy = _get_url(site, proxy)
             if result_proxy[0] == sites[site]['status'] and result_proxy[1].find(sites[site]['lookfor']) != -1:
                 print("[✓] Сайт открывается через прокси")
                 successes_proxy += 1
             else:
-                print("[☠] Сайт не открывается через прокси")
+                if result_proxy[0] == sites[site]['status']:
+                    print("[☠] Получен неожиданный ответ, скорее всего, "
+                          "страница-заглушка провайдера. Считаем заблокированным.")
+                else:
+                    print("[☠] Сайт не открывается через прокси")
                 isup = check_isup(site)
                 if isup is None:
                     blocks_ambiguous += 1

--- a/blockcheck.py
+++ b/blockcheck.py
@@ -259,12 +259,22 @@ def check_isup(page_url):
     `page_url` must be a string and presumed to be sanitized (but
     doesn't have to be the domain and nothing else, isup.me accepts
     full URLs)
+
+    isup.me can't check HTTPS URL yet, so we return True for them.
+    It's still useful to call check_isup even on HTTPS URLs for two
+    reasons: because we may switch to a service that can can check them
+    in the future and because check_isup will output a notification for
+    the user.
     """
     #Note that isup.me doesn't use HTTPS and therefore the ISP can slip
     #false information (and if it gets blocked, the error page by the ISP can
     #happen to have the markers we look for). We should inform the user about
     #this possibility when showing results.
     if disable_isup:
+        return True
+    elif page_url.startswith("https://"):
+        print("[☠] {} не поддерживает HTTPS, считаем, что сайт работает, "
+              "а проблемы только у нас".format(isup_server))
         return True
 
     print("\tПроверяем доступность через {}".format(isup_server))


### PR DESCRIPTION
Поскольку isup.me, похоже, перестал поддерживать HTTPS (а может, у меня плохая память, и он их никогда не поддерживал), check_isup() теперь будет возвращать True (сайт доступен) для каждого сайта HTTPS.

Считаю, что это решение лучше, чем, например, удалять проверку из test_https_cert, поскольку isup может начать-таки поддерживать HTTPS или мы можем перейти на другой сервис, который будет поддерживать HTTPS, и тогда нужно будет поменять только одну функцию.

Кроме того, теперь в следующих двух ситуациях будут выводиться **разные** сообщения:

* Если сайт не отвечает (или отвечает с неожиданным статус-кодом).
* И если сайт отвечает с ожидаемым кодом, но возвращает неожиданную страницу (например, заглушку провайдера).

Считаю это разумным по следующей причине. Так как скрипт проверяет код страниц на наличие определённых подстрок, если он устареет, то он может начать неправильно определять доступные сайты как недоступные (это уже происходило, например, с Рутрекером). Результат может запутать пользователя («Как так сайт недоступен, когда он открывается?!») и подорвать доверие к скрипту. Особенно учитывая следующую строчку в логе (про isup.me). Поэтому если вместо этого честно сказать, что сайт отвечает, но неожиданным образом, ситуация будет для пользователя яснее.